### PR TITLE
Rename "checking" to "current" as canonical account type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Budgie is a personal finance tracker built as a terminal UI application in Go. It uses the Charmbracelet ecosystem (bubbletea, lipgloss, bubbles) for the TUI and SQLite for data storage. Data is stored in `~/.local/share/budgie/budgie.db`.
+
+## Build & Run Commands
+
+```bash
+go build ./cmd/budgie    # Build binary to ./budgie
+go run ./cmd/budgie      # Run directly without building
+go fmt ./...             # Format code
+go vet ./...             # Check for issues
+go test ./...            # Run tests (none exist yet)
+```
+
+## Architecture
+
+The codebase follows the Elm-style Model-View-Update architecture via bubbletea:
+
+- **cmd/budgie/** - Entry point, initializes database and UI
+- **internal/model/** - Pure domain types (Account, Transaction, AccountType)
+- **internal/db/** - Database connection, migrations, and query functions
+- **internal/ui/** - Bubbletea models and views (summary dashboard)
+
+### Key Patterns
+
+- **Integer arithmetic for currency**: All amounts are stored as int64 in pence (not pounds) to avoid floating-point errors. Conversion to display format happens only in `internal/ui/format.go`.
+- **Async data loading**: Dashboard fetches data via Init() commands and displays "Loading..." until data arrives. No blocking DB calls in the UI thread.
+- **UK localization**: Currency as GBP with thousands separators, dates as DD/MM/YYYY, account type "current" used throughout.
+
+### Database Schema
+
+Two tables: `accounts` (id, name, type) and `transactions` (id, account_id, date, description, amount, category). Foreign key from transactions to accounts. Amount stored in pence as INTEGER.
+
+## Dependencies
+
+Requires Go 1.24+ and CGo enabled (for sqlite3 driver). Key dependencies:
+- `github.com/charmbracelet/bubbletea` - TUI framework
+- `github.com/charmbracelet/lipgloss` - Terminal styling
+- `github.com/mattn/go-sqlite3` - SQLite driver

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ budgie is a terminal UI application for tracking income, expenses, and account b
   - Monthly income vs expenses with a net figure
   - Last 10 transactions with date, account, description, and amount
 - **SQLite database** -- schema for accounts (current, savings, credit, cash) and transactions with automatic migration on first run
-- **UK localisation** -- all currency displayed in GBP (£), dates formatted as DD/MM/YYYY, "checking" account type displayed as "current"
+- **UK localisation** -- all currency displayed in GBP (£), dates formatted as DD/MM/YYYY, account types use British English ("current" not "checking")
 
 ### What doesn't exist yet
 
@@ -62,7 +62,7 @@ The app uses British English and GBP throughout:
 | Currency | £1,200.00 |
 | Negative currency | -£45.00 |
 | Date format | 28/01/2026 |
-| Account type display | "current" (stored as "checking" for DB compatibility) |
+| Account type display | "current" |
 
 ## Project structure
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -42,7 +42,7 @@ func migrate(db *sql.DB) error {
 		CREATE TABLE IF NOT EXISTS accounts (
 			id   INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL UNIQUE,
-			type TEXT NOT NULL CHECK(type IN ('checking','savings','credit','cash'))
+			type TEXT NOT NULL CHECK(type IN ('current','savings','credit','cash'))
 		);
 
 		CREATE TABLE IF NOT EXISTS transactions (
@@ -58,6 +58,8 @@ func migrate(db *sql.DB) error {
 			ON transactions(account_id);
 		CREATE INDEX IF NOT EXISTS idx_transactions_date
 			ON transactions(date);
+
+		UPDATE accounts SET type = 'current' WHERE type = 'checking';
 	`)
 	return err
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -11,7 +11,7 @@ type Account struct {
 type AccountType string
 
 const (
-	AccountTypeChecking AccountType = "checking"
+	AccountTypeCurrent AccountType = "current"
 	AccountTypeSavings  AccountType = "savings"
 	AccountTypeCredit   AccountType = "credit"
 	AccountTypeCash     AccountType = "cash"

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -52,11 +52,3 @@ func addThousandsSeparator(n int64) string {
 func formatDate(t time.Time) string {
 	return t.Format("02/01/2006")
 }
-
-// displayAccountType maps the internal account type to a UK-friendly label.
-func displayAccountType(t string) string {
-	if t == "checking" {
-		return "current"
-	}
-	return t
-}

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -143,7 +143,7 @@ func (m summaryModel) renderAccounts() string {
 		if len(a.Name) > nameW {
 			nameW = len(a.Name)
 		}
-		dt := displayAccountType(a.Type)
+		dt := a.Type
 		if len(dt) > typeW {
 			typeW = len(dt)
 		}
@@ -175,7 +175,7 @@ func (m summaryModel) renderAccounts() string {
 	b.WriteString("\n")
 
 	for _, a := range m.data.accounts {
-		row := fmt.Sprintf(fmtRow, a.Name, displayAccountType(a.Type), formatPence(a.Balance))
+		row := fmt.Sprintf(fmtRow, a.Name, a.Type, formatPence(a.Balance))
 		b.WriteString(row)
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary

- Renames `AccountTypeChecking` to `AccountTypeCurrent` with value `"current"` so the UK term is used everywhere, not just at display time
- Updates the DB CHECK constraint and adds a migration step (`UPDATE accounts SET type = 'current' WHERE type = 'checking'`) for existing data
- Removes the now-unnecessary `displayAccountType()` function and its call sites in the dashboard

Closes #19

## Test plan

- [x] `go build ./cmd/budgie` compiles cleanly
- [x] `go vet ./...` reports no issues
- [ ] Launch the app — dashboard renders with "current" as the account type label
- [ ] With an existing database containing "checking" rows, verify they are migrated to "current" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)