### PR TITLE
Add transaction CRUD: insert, delete, form UI, and wiring

### DIFF
--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -113,6 +113,37 @@ func ListAccounts(db *sql.DB) ([]model.Account, error) {
 	return out, rows.Err()
 }
 
+// InsertTransaction creates a new transaction and returns its ID.
+func InsertTransaction(db *sql.DB, accountID int64, date time.Time, description string, amount int64, category string) (int64, error) {
+	result, err := db.Exec(
+		`INSERT INTO transactions (account_id, date, description, amount, category) VALUES (?, ?, ?, ?, ?)`,
+		accountID, date.Format("2006-01-02"), description, amount, category,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+			return 0, errors.New("account does not exist")
+		}
+		return 0, fmt.Errorf("inserting transaction: %w", err)
+	}
+	return result.LastInsertId()
+}
+
+// DeleteTransaction removes a transaction by ID. Returns an error if it doesn't exist.
+func DeleteTransaction(db *sql.DB, transactionID int64) error {
+	result, err := db.Exec(`DELETE FROM transactions WHERE id = ?`, transactionID)
+	if err != nil {
+		return fmt.Errorf("deleting transaction: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("transaction %d not found", transactionID)
+	}
+	return nil
+}
+
 // AccountBalances returns every account with its computed balance.
 func AccountBalances(db *sql.DB) ([]AccountBalance, error) {
 	rows, err := db.Query(`

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -180,6 +180,97 @@ func TestListAccounts_CorrectFields(t *testing.T) {
 	}
 }
 
+// --- InsertTransaction tests ---
+
+func TestInsertTransaction_Valid(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	id, err := InsertTransaction(db, acctID, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), "Salary", 150000, "income")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive ID, got %d", id)
+	}
+}
+
+func TestInsertTransaction_EmptyDescriptionAndCategory(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	_, err := InsertTransaction(db, acctID, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), "", 5000, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInsertTransaction_InvalidAccount(t *testing.T) {
+	db := testDB(t)
+	_, err := InsertTransaction(db, 9999, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), "Test", 1000, "")
+	if err == nil {
+		t.Fatal("expected error for non-existent account")
+	}
+}
+
+func TestInsertTransaction_NegativeAmount(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	id, err := InsertTransaction(db, acctID, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC), "Rent", -80000, "housing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("expected positive ID, got %d", id)
+	}
+}
+
+func TestInsertTransaction_StoresDateCorrectly(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	date := time.Date(2026, 3, 25, 0, 0, 0, 0, time.UTC)
+	InsertTransaction(db, acctID, date, "Test", 1000, "")
+
+	txs, err := RecentTransactions(db, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txs) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txs))
+	}
+	if txs[0].Date != date {
+		t.Errorf("expected date %v, got %v", date, txs[0].Date)
+	}
+}
+
+// --- DeleteTransaction tests ---
+
+func TestDeleteTransaction_Valid(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	insertTestTransaction(t, db, acctID, "2026-01-15", "ToDelete", 1000)
+
+	// Get the transaction ID
+	var txID int64
+	db.QueryRow(`SELECT id FROM transactions LIMIT 1`).Scan(&txID)
+
+	if err := DeleteTransaction(db, txID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify it's gone
+	txs, _ := RecentTransactions(db, 10)
+	if len(txs) != 0 {
+		t.Errorf("expected 0 transactions after delete, got %d", len(txs))
+	}
+}
+
+func TestDeleteTransaction_NotFound(t *testing.T) {
+	db := testDB(t)
+	err := DeleteTransaction(db, 9999)
+	if err == nil {
+		t.Fatal("expected error for non-existent transaction")
+	}
+}
+
 // --- AccountBalances tests ---
 
 func TestAccountBalances_Empty(t *testing.T) {

--- a/internal/ui/transaction_form.go
+++ b/internal/ui/transaction_form.go
@@ -1,0 +1,368 @@
+package ui
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"budgie/internal/db"
+	"budgie/internal/model"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// txFormField tracks which field is focused.
+type txFormField int
+
+const (
+	txFieldAccount txFormField = iota
+	txFieldDate
+	txFieldDescription
+	txFieldAmount
+	txFieldCategory
+	txFieldDirection
+	txFieldSubmit
+	txFieldCount // sentinel for wrapping
+)
+
+// transactionInsertedMsg is sent when the transaction was successfully created.
+type transactionInsertedMsg struct{}
+
+// transactionInsertErrMsg is sent when the DB insert fails.
+type transactionInsertErrMsg struct{ err error }
+
+// transactionFormCancelledMsg is sent when the user presses Esc.
+type transactionFormCancelledMsg struct{}
+
+// accountsLoadedMsg delivers the account list to the form.
+type accountsLoadedMsg struct {
+	accounts []model.Account
+	err      error
+}
+
+type txDirection int
+
+const (
+	txExpense txDirection = iota
+	txIncome
+)
+
+// transactionFormModel is the bubbletea model for the add-transaction form.
+type transactionFormModel struct {
+	database     *sql.DB
+	accounts     []model.Account
+	accountIndex int
+	dateInput    textinput.Model
+	descInput    textinput.Model
+	amountInput  textinput.Model
+	catInput     textinput.Model
+	direction    txDirection
+	focused      txFormField
+	err          string
+	loading      bool
+}
+
+func newTransactionFormModel(database *sql.DB) transactionFormModel {
+	dateIn := textinput.New()
+	dateIn.Placeholder = "DD/MM/YYYY"
+	dateIn.CharLimit = 10
+	dateIn.SetValue(time.Now().Format("02/01/2006"))
+
+	descIn := textinput.New()
+	descIn.Placeholder = "Description"
+	descIn.CharLimit = 100
+
+	amountIn := textinput.New()
+	amountIn.Placeholder = "0.00"
+	amountIn.CharLimit = 15
+
+	catIn := textinput.New()
+	catIn.Placeholder = "Category"
+	catIn.CharLimit = 50
+
+	return transactionFormModel{
+		database:    database,
+		dateInput:   dateIn,
+		descInput:   descIn,
+		amountInput: amountIn,
+		catInput:    catIn,
+		direction:   txExpense,
+		focused:     txFieldAccount,
+		loading:     true,
+	}
+}
+
+func (m transactionFormModel) Init() tea.Cmd {
+	database := m.database
+	return func() tea.Msg {
+		accounts, err := db.ListAccounts(database)
+		return accountsLoadedMsg{accounts: accounts, err: err}
+	}
+}
+
+func (m transactionFormModel) Update(msg tea.Msg) (transactionFormModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case accountsLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		if len(msg.accounts) == 0 {
+			m.err = "No accounts exist. Create an account first."
+			return m, nil
+		}
+		m.accounts = msg.accounts
+		return m, nil
+
+	case transactionInsertErrMsg:
+		m.err = msg.err.Error()
+		return m, nil
+
+	case tea.KeyMsg:
+		m.err = ""
+
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg { return transactionFormCancelledMsg{} }
+
+		case "tab", "down":
+			return m.focusNext(), nil
+
+		case "shift+tab", "up":
+			return m.focusPrev(), nil
+
+		case "enter":
+			if m.focused == txFieldSubmit {
+				return m.submit()
+			}
+			return m.focusNext(), nil
+
+		case "left":
+			if m.focused == txFieldAccount && len(m.accounts) > 0 {
+				m.accountIndex = (m.accountIndex - 1 + len(m.accounts)) % len(m.accounts)
+				return m, nil
+			}
+			if m.focused == txFieldDirection {
+				m.direction = txExpense
+				return m, nil
+			}
+
+		case "right":
+			if m.focused == txFieldAccount && len(m.accounts) > 0 {
+				m.accountIndex = (m.accountIndex + 1) % len(m.accounts)
+				return m, nil
+			}
+			if m.focused == txFieldDirection {
+				m.direction = txIncome
+				return m, nil
+			}
+		}
+	}
+
+	// Update the focused text input.
+	var cmd tea.Cmd
+	switch m.focused {
+	case txFieldDate:
+		m.dateInput, cmd = m.dateInput.Update(msg)
+	case txFieldDescription:
+		m.descInput, cmd = m.descInput.Update(msg)
+	case txFieldAmount:
+		m.amountInput, cmd = m.amountInput.Update(msg)
+	case txFieldCategory:
+		m.catInput, cmd = m.catInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m transactionFormModel) focusField(field txFormField) transactionFormModel {
+	m.dateInput.Blur()
+	m.descInput.Blur()
+	m.amountInput.Blur()
+	m.catInput.Blur()
+
+	m.focused = field
+	switch field {
+	case txFieldDate:
+		m.dateInput.Focus()
+	case txFieldDescription:
+		m.descInput.Focus()
+	case txFieldAmount:
+		m.amountInput.Focus()
+	case txFieldCategory:
+		m.catInput.Focus()
+	}
+	return m
+}
+
+func (m transactionFormModel) focusNext() transactionFormModel {
+	next := (m.focused + 1) % txFieldCount
+	return m.focusField(next)
+}
+
+func (m transactionFormModel) focusPrev() transactionFormModel {
+	prev := (m.focused - 1 + txFieldCount) % txFieldCount
+	return m.focusField(prev)
+}
+
+func (m transactionFormModel) submit() (transactionFormModel, tea.Cmd) {
+	if len(m.accounts) == 0 {
+		m.err = "No accounts exist. Create an account first."
+		return m, nil
+	}
+
+	// Parse date
+	dateStr := strings.TrimSpace(m.dateInput.Value())
+	date, err := time.Parse("02/01/2006", dateStr)
+	if err != nil {
+		m.err = "Invalid date. Use DD/MM/YYYY format."
+		return m, nil
+	}
+
+	// Parse amount
+	amountStr := strings.TrimSpace(m.amountInput.Value())
+	amountStr = strings.TrimPrefix(amountStr, "£")
+	amountStr = strings.ReplaceAll(amountStr, ",", "")
+	if amountStr == "" {
+		m.err = "Amount is required"
+		return m, nil
+	}
+	amountFloat, err := strconv.ParseFloat(amountStr, 64)
+	if err != nil || amountFloat < 0 {
+		m.err = "Invalid amount. Enter a positive number like 12.50"
+		return m, nil
+	}
+	if amountFloat == 0 {
+		m.err = "Amount must be greater than zero"
+		return m, nil
+	}
+	amountPence := int64(amountFloat*100 + 0.5) // round to nearest pence
+	if m.direction == txExpense {
+		amountPence = -amountPence
+	}
+
+	accountID := m.accounts[m.accountIndex].ID
+	description := strings.TrimSpace(m.descInput.Value())
+	category := strings.TrimSpace(m.catInput.Value())
+	database := m.database
+
+	cmd := func() tea.Msg {
+		_, err := db.InsertTransaction(database, accountID, date, description, amountPence, category)
+		if err != nil {
+			return transactionInsertErrMsg{err: err}
+		}
+		return transactionInsertedMsg{}
+	}
+	return m, cmd
+}
+
+func (m transactionFormModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(sectionTitle.Render("Add Transaction"))
+	b.WriteString("\n\n")
+
+	if m.loading {
+		b.WriteString("  Loading accounts...")
+		return b.String()
+	}
+
+	labelW := 14
+
+	// Account picker
+	label := m.labelStyle(txFieldAccount, labelW)
+	if len(m.accounts) > 0 {
+		b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Account:"), m.renderAccountPicker()))
+	} else {
+		b.WriteString(fmt.Sprintf("  %s (none)\n", label.Render("Account:")))
+	}
+
+	// Date
+	label = m.labelStyle(txFieldDate, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Date:"), m.dateInput.View()))
+
+	// Description
+	label = m.labelStyle(txFieldDescription, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Description:"), m.descInput.View()))
+
+	// Amount
+	label = m.labelStyle(txFieldAmount, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Amount (£):"), m.amountInput.View()))
+
+	// Category
+	label = m.labelStyle(txFieldCategory, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Category:"), m.catInput.View()))
+
+	// Direction toggle
+	label = m.labelStyle(txFieldDirection, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Type:"), m.renderDirectionToggle()))
+
+	// Error
+	if m.err != "" {
+		b.WriteString(fmt.Sprintf("\n  %s\n", formErrorStyle.Render(m.err)))
+	}
+
+	// Submit
+	b.WriteString("\n")
+	if m.focused == txFieldSubmit {
+		b.WriteString(fmt.Sprintf("  %s", formActiveButton.Render("Add Transaction")))
+	} else {
+		b.WriteString(fmt.Sprintf("  %s", formButtonStyle.Render("Add Transaction")))
+	}
+	b.WriteString("\n")
+
+	// Help
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  tab/shift+tab: navigate  enter: submit  esc: cancel"))
+
+	return b.String()
+}
+
+func (m transactionFormModel) labelStyle(field txFormField, width int) lipgloss.Style {
+	if m.focused == field {
+		return formActiveLabel.Width(width)
+	}
+	return formLabelStyle.Width(width)
+}
+
+func (m transactionFormModel) renderAccountPicker() string {
+	var parts []string
+	for i, a := range m.accounts {
+		s := a.Name
+		if i == m.accountIndex {
+			if m.focused == txFieldAccount {
+				s = formActiveButton.Render(s)
+			} else {
+				s = lipgloss.NewStyle().Bold(true).Render("[" + s + "]")
+			}
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m transactionFormModel) renderDirectionToggle() string {
+	expense := "Expense"
+	income := "Income"
+
+	if m.direction == txExpense {
+		if m.focused == txFieldDirection {
+			expense = formActiveButton.Render(expense)
+		} else {
+			expense = lipgloss.NewStyle().Bold(true).Render("[" + expense + "]")
+		}
+	}
+	if m.direction == txIncome {
+		if m.focused == txFieldDirection {
+			income = formActiveButton.Render(income)
+		} else {
+			income = lipgloss.NewStyle().Bold(true).Render("[" + income + "]")
+		}
+	}
+
+	return expense + "  " + income
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -12,6 +12,7 @@ type view int
 const (
 	viewSummary view = iota
 	viewAccountForm
+	viewTransactionForm
 )
 
 var (
@@ -24,12 +25,13 @@ var (
 )
 
 type Model struct {
-	db          *sql.DB
-	width       int
-	height      int
-	active      view
-	summary     summaryModel
-	accountForm accountFormModel
+	db              *sql.DB
+	width           int
+	height          int
+	active          view
+	summary         summaryModel
+	accountForm     accountFormModel
+	transactionForm transactionFormModel
 }
 
 func New(db *sql.DB) Model {
@@ -55,12 +57,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 
-	case accountInsertedMsg:
+	case accountInsertedMsg, transactionInsertedMsg:
 		m.active = viewSummary
 		m.summary = newSummaryModel(m.db)
 		return m, m.summary.Init()
 
-	case AccountFormCancelled:
+	case AccountFormCancelled, transactionFormCancelledMsg:
 		m.active = viewSummary
 		return m, nil
 	}
@@ -70,6 +72,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateSummary(msg)
 	case viewAccountForm:
 		return m.updateAccountForm(msg)
+	case viewTransactionForm:
+		return m.updateTransactionForm(msg)
 	}
 
 	return m, nil
@@ -84,6 +88,10 @@ func (m Model) updateSummary(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.active = viewAccountForm
 			m.accountForm = newAccountFormModel(m.db)
 			return m, m.accountForm.Init()
+		case "t":
+			m.active = viewTransactionForm
+			m.transactionForm = newTransactionFormModel(m.db)
+			return m, m.transactionForm.Init()
 		}
 	}
 
@@ -98,6 +106,12 @@ func (m Model) updateAccountForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m Model) updateTransactionForm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.transactionForm, cmd = m.transactionForm.Update(msg)
+	return m, cmd
+}
+
 func (m Model) View() string {
 	title := titleStyle.Render("budgie")
 
@@ -107,9 +121,12 @@ func (m Model) View() string {
 	switch m.active {
 	case viewSummary:
 		content = m.summary.View()
-		help = helpStyle.Render("a: add account  q: quit")
+		help = helpStyle.Render("a: add account  t: add transaction  q: quit")
 	case viewAccountForm:
 		content = m.accountForm.View()
+		help = ""
+	case viewTransactionForm:
+		content = m.transactionForm.View()
 		help = ""
 	}
 


### PR DESCRIPTION
## Summary

### DB layer (`internal/db/queries.go`)
- `InsertTransaction(db, accountID, date, description, amountPence, category)` — creates a transaction, user-friendly error for invalid account
- `DeleteTransaction(db, transactionID)` — removes by ID, errors if not found

### Transaction form (`internal/ui/transaction_form.go`)
- Account picker (cycles through existing accounts with left/right)
- Date input (DD/MM/YYYY, defaults to today)
- Description and category text inputs
- Amount input (accepts `£12.50` or `12.50`, converts to pence)
- Income/Expense toggle (determines sign)
- Tab/shift+tab navigation, enter to submit, esc to cancel
- Validation: date format, positive numeric amount, account must exist

### Wiring (`internal/ui/ui.go`)
- Press `t` from dashboard to open the transaction form
- On success: returns to dashboard and refreshes all data
- On error: displays inline on the form
- Dashboard help bar updated: `a: add account  t: add transaction  q: quit`

### Tests (`internal/db/queries_test.go`)
- 7 new tests covering InsertTransaction and DeleteTransaction

Closes #6, closes #7, closes #8, closes #9

## Test plan

- [x] `go build ./...` and `go vet ./...` pass
- [x] `go test ./...` — all 28 tests pass (21 existing + 7 new)
- [x] From dashboard, press `t` — transaction form opens with accounts loaded
- [x] Select account, fill in fields, submit — transaction created, dashboard refreshes
- [x] Toggle income/expense — amount sign flips correctly
- [ ] Submit with invalid date — inline error
- [ ] Submit with empty/negative/non-numeric amount — inline error
- [ ] Press `esc` — returns to dashboard without creating anything
- [ ] Press `t` with no accounts — shows "Create an account first" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)