### PR TITLE
Add Monzo CSV import with dedup and preview flow

### DIFF
--- a/internal/csvimport/monzo.go
+++ b/internal/csvimport/monzo.go
@@ -12,21 +12,24 @@ import (
 
 // MonzoTransaction represents a single parsed row from a Monzo CSV export.
 type MonzoTransaction struct {
-	ExternalID    string
-	Date          time.Time
-	Description   string // from Monzo "Name" column
-	Amount        int64  // pence, signed
-	Category      string
-	Type          string // e.g. "card_payment"
-	Notes         string
-	LocalAmount   *int64 // nil if domestic/GBP
-	LocalCurrency string // "" if GBP
+	ExternalID  string
+	Date        time.Time
+	Description string // from Monzo "Name" column
+	Amount      int64  // pence, signed
+	Category    string
+	Type        string // e.g. "card_payment"
+	Notes       string
+	LocalAmount string // e.g. "-6.25 EUR" or "" for domestic
+	Emoji       string
+	SourceDesc  string // Monzo "Description" column
 }
 
 var requiredColumns = []string{
 	"Transaction ID",
 	"Date",
 	"Name",
+	"Emoji",
+	"Description",
 	"Amount",
 	"Category",
 	"Type",
@@ -99,6 +102,8 @@ func ParseMonzoCSV(path string) ([]MonzoTransaction, error) {
 			Category:    row[colIndex["Category"]],
 			Type:        row[colIndex["Type"]],
 			Notes:       row[colIndex["Notes and #tags"]],
+			Emoji:       row[colIndex["Emoji"]],
+			SourceDesc:  row[colIndex["Description"]],
 		}
 
 		currency := row[colIndex["Currency"]]
@@ -107,9 +112,7 @@ func ParseMonzoCSV(path string) ([]MonzoTransaction, error) {
 			localAmountStr := row[colIndex["Local amount"]]
 			localFloat, err := strconv.ParseFloat(localAmountStr, 64)
 			if err == nil {
-				localPence := int64(math.Round(localFloat * 100))
-				tx.LocalAmount = &localPence
-				tx.LocalCurrency = localCurrency
+				tx.LocalAmount = fmt.Sprintf("%.2f %s", localFloat, localCurrency)
 			}
 		}
 

--- a/internal/csvimport/monzo.go
+++ b/internal/csvimport/monzo.go
@@ -1,0 +1,130 @@
+package csvimport
+
+import (
+	"encoding/csv"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MonzoTransaction represents a single parsed row from a Monzo CSV export.
+type MonzoTransaction struct {
+	ExternalID    string
+	Date          time.Time
+	Description   string // from Monzo "Name" column
+	Amount        int64  // pence, signed
+	Category      string
+	Type          string // e.g. "card_payment"
+	Notes         string
+	LocalAmount   *int64 // nil if domestic/GBP
+	LocalCurrency string // "" if GBP
+}
+
+var requiredColumns = []string{
+	"Transaction ID",
+	"Date",
+	"Name",
+	"Amount",
+	"Category",
+	"Type",
+	"Notes and #tags",
+	"Currency",
+	"Local amount",
+	"Local currency",
+}
+
+// ParseMonzoCSV reads a Monzo CSV export and returns parsed transactions.
+// Rows with empty Transaction ID are skipped.
+func ParseMonzoCSV(path string) ([]MonzoTransaction, error) {
+	path = expandTilde(path)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not open file: %w", err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("reading CSV: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("CSV file is empty")
+	}
+
+	header := records[0]
+	colIndex := make(map[string]int, len(header))
+	for i, col := range header {
+		colIndex[col] = i
+	}
+
+	for _, req := range requiredColumns {
+		if _, ok := colIndex[req]; !ok {
+			return nil, fmt.Errorf("missing required column: %q", req)
+		}
+	}
+
+	var out []MonzoTransaction
+	for i, row := range records[1:] {
+		lineNum := i + 2 // 1-indexed, skip header
+
+		extID := row[colIndex["Transaction ID"]]
+		if extID == "" {
+			continue
+		}
+
+		dateStr := row[colIndex["Date"]]
+		date, err := time.Parse("02/01/2006", dateStr)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: invalid date %q", lineNum, dateStr)
+		}
+
+		amountStr := row[colIndex["Amount"]]
+		amountFloat, err := strconv.ParseFloat(amountStr, 64)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: invalid amount %q", lineNum, amountStr)
+		}
+		amount := int64(math.Round(amountFloat * 100))
+
+		tx := MonzoTransaction{
+			ExternalID:  extID,
+			Date:        date,
+			Description: row[colIndex["Name"]],
+			Amount:      amount,
+			Category:    row[colIndex["Category"]],
+			Type:        row[colIndex["Type"]],
+			Notes:       row[colIndex["Notes and #tags"]],
+		}
+
+		currency := row[colIndex["Currency"]]
+		localCurrency := row[colIndex["Local currency"]]
+		if localCurrency != "" && localCurrency != currency {
+			localAmountStr := row[colIndex["Local amount"]]
+			localFloat, err := strconv.ParseFloat(localAmountStr, 64)
+			if err == nil {
+				localPence := int64(math.Round(localFloat * 100))
+				tx.LocalAmount = &localPence
+				tx.LocalCurrency = localCurrency
+			}
+		}
+
+		out = append(out, tx)
+	}
+
+	return out, nil
+}
+
+func expandTilde(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
+}

--- a/internal/csvimport/monzo_test.go
+++ b/internal/csvimport/monzo_test.go
@@ -1,0 +1,155 @@
+package csvimport
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempCSV(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "monzo.csv")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing temp CSV: %v", err)
+	}
+	return path
+}
+
+const validHeader = "Transaction ID,Date,Time,Type,Name,Emoji,Category,Amount,Currency,Local amount,Local currency,Notes and #tags,Address,Receipt,Description,Category split,Money Out,Money In\n"
+
+func TestParseMonzoCSV_ValidFile(t *testing.T) {
+	csv := validHeader +
+		"tx_001,07/02/2026,14:30:00,card_payment,Tesco,,groceries,-15.50,GBP,-15.50,GBP,weekly shop,,,,,-15.50,\n"
+
+	path := writeTempCSV(t, csv)
+	txns, err := ParseMonzoCSV(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txns))
+	}
+
+	tx := txns[0]
+	if tx.ExternalID != "tx_001" {
+		t.Errorf("expected external ID 'tx_001', got %q", tx.ExternalID)
+	}
+	if tx.Date.Day() != 7 || tx.Date.Month() != 2 || tx.Date.Year() != 2026 {
+		t.Errorf("unexpected date: %v", tx.Date)
+	}
+	if tx.Description != "Tesco" {
+		t.Errorf("expected description 'Tesco', got %q", tx.Description)
+	}
+	if tx.Amount != -1550 {
+		t.Errorf("expected amount -1550, got %d", tx.Amount)
+	}
+	if tx.Category != "groceries" {
+		t.Errorf("expected category 'groceries', got %q", tx.Category)
+	}
+	if tx.Type != "card_payment" {
+		t.Errorf("expected type 'card_payment', got %q", tx.Type)
+	}
+	if tx.Notes != "weekly shop" {
+		t.Errorf("expected notes 'weekly shop', got %q", tx.Notes)
+	}
+	if tx.LocalAmount != nil {
+		t.Errorf("expected nil LocalAmount for GBP transaction, got %d", *tx.LocalAmount)
+	}
+	if tx.LocalCurrency != "" {
+		t.Errorf("expected empty LocalCurrency for GBP transaction, got %q", tx.LocalCurrency)
+	}
+}
+
+func TestParseMonzoCSV_FileNotFound(t *testing.T) {
+	_, err := ParseMonzoCSV("/nonexistent/path/monzo.csv")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "could not open file") {
+		t.Errorf("expected 'could not open file' error, got: %v", err)
+	}
+}
+
+func TestParseMonzoCSV_InvalidHeader(t *testing.T) {
+	csv := "ID,Date,Amount\n" +
+		"1,07/02/2026,10.00\n"
+
+	path := writeTempCSV(t, csv)
+	_, err := ParseMonzoCSV(path)
+	if err == nil {
+		t.Fatal("expected error for invalid header")
+	}
+	if !strings.Contains(err.Error(), "missing required column") {
+		t.Errorf("expected 'missing required column' error, got: %v", err)
+	}
+}
+
+func TestParseMonzoCSV_EmptyFile(t *testing.T) {
+	path := writeTempCSV(t, validHeader)
+	txns, err := ParseMonzoCSV(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txns) != 0 {
+		t.Fatalf("expected 0 transactions, got %d", len(txns))
+	}
+}
+
+func TestParseMonzoCSV_InvalidAmount(t *testing.T) {
+	csv := validHeader +
+		"tx_001,07/02/2026,14:30:00,card_payment,Tesco,,groceries,abc,GBP,,GBP,,,,,,,\n"
+
+	path := writeTempCSV(t, csv)
+	_, err := ParseMonzoCSV(path)
+	if err == nil {
+		t.Fatal("expected error for invalid amount")
+	}
+	if !strings.Contains(err.Error(), "invalid amount") {
+		t.Errorf("expected 'invalid amount' error, got: %v", err)
+	}
+}
+
+func TestParseMonzoCSV_ForeignCurrency(t *testing.T) {
+	csv := validHeader +
+		"tx_002,07/02/2026,14:30:00,card_payment,Cafe,,eating_out,-5.00,GBP,-6.25,EUR,,,,,,-5.00,\n"
+
+	path := writeTempCSV(t, csv)
+	txns, err := ParseMonzoCSV(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(txns))
+	}
+
+	tx := txns[0]
+	if tx.LocalAmount == nil {
+		t.Fatal("expected non-nil LocalAmount for foreign currency transaction")
+	}
+	if *tx.LocalAmount != -625 {
+		t.Errorf("expected local amount -625, got %d", *tx.LocalAmount)
+	}
+	if tx.LocalCurrency != "EUR" {
+		t.Errorf("expected local currency 'EUR', got %q", tx.LocalCurrency)
+	}
+}
+
+func TestParseMonzoCSV_SkipsEmptyExternalID(t *testing.T) {
+	csv := validHeader +
+		"tx_001,07/02/2026,14:30:00,card_payment,Tesco,,groceries,-15.50,GBP,-15.50,GBP,,,,,,-15.50,\n" +
+		",07/02/2026,14:30:00,card_payment,Empty,,misc,-1.00,GBP,-1.00,GBP,,,,,,-1.00,\n"
+
+	path := writeTempCSV(t, csv)
+	txns, err := ParseMonzoCSV(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(txns) != 1 {
+		t.Fatalf("expected 1 transaction (skipping empty ID), got %d", len(txns))
+	}
+	if txns[0].ExternalID != "tx_001" {
+		t.Errorf("expected external ID 'tx_001', got %q", txns[0].ExternalID)
+	}
+}

--- a/internal/csvimport/monzo_test.go
+++ b/internal/csvimport/monzo_test.go
@@ -54,11 +54,14 @@ func TestParseMonzoCSV_ValidFile(t *testing.T) {
 	if tx.Notes != "weekly shop" {
 		t.Errorf("expected notes 'weekly shop', got %q", tx.Notes)
 	}
-	if tx.LocalAmount != nil {
-		t.Errorf("expected nil LocalAmount for GBP transaction, got %d", *tx.LocalAmount)
+	if tx.LocalAmount != "" {
+		t.Errorf("expected empty LocalAmount for GBP transaction, got %q", tx.LocalAmount)
 	}
-	if tx.LocalCurrency != "" {
-		t.Errorf("expected empty LocalCurrency for GBP transaction, got %q", tx.LocalCurrency)
+	if tx.Emoji != "" {
+		t.Errorf("expected empty Emoji, got %q", tx.Emoji)
+	}
+	if tx.SourceDesc != "" {
+		t.Errorf("expected empty SourceDesc, got %q", tx.SourceDesc)
 	}
 }
 
@@ -113,7 +116,7 @@ func TestParseMonzoCSV_InvalidAmount(t *testing.T) {
 
 func TestParseMonzoCSV_ForeignCurrency(t *testing.T) {
 	csv := validHeader +
-		"tx_002,07/02/2026,14:30:00,card_payment,Cafe,,eating_out,-5.00,GBP,-6.25,EUR,,,,,,-5.00,\n"
+		"tx_002,07/02/2026,14:30:00,card_payment,Cafe,☕,eating_out,-5.00,GBP,-6.25,EUR,,,,cafe payment,,-5.00,\n"
 
 	path := writeTempCSV(t, csv)
 	txns, err := ParseMonzoCSV(path)
@@ -125,14 +128,14 @@ func TestParseMonzoCSV_ForeignCurrency(t *testing.T) {
 	}
 
 	tx := txns[0]
-	if tx.LocalAmount == nil {
-		t.Fatal("expected non-nil LocalAmount for foreign currency transaction")
+	if tx.LocalAmount != "-6.25 EUR" {
+		t.Errorf("expected local amount %q, got %q", "-6.25 EUR", tx.LocalAmount)
 	}
-	if *tx.LocalAmount != -625 {
-		t.Errorf("expected local amount -625, got %d", *tx.LocalAmount)
+	if tx.Emoji != "☕" {
+		t.Errorf("expected emoji '☕', got %q", tx.Emoji)
 	}
-	if tx.LocalCurrency != "EUR" {
-		t.Errorf("expected local currency 'EUR', got %q", tx.LocalCurrency)
+	if tx.SourceDesc != "cafe payment" {
+		t.Errorf("expected source desc 'cafe payment', got %q", tx.SourceDesc)
 	}
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -55,8 +55,9 @@ func migrate(db *sql.DB) error {
 			external_id    TEXT,
 			notes          TEXT    NOT NULL DEFAULT '',
 			type           TEXT    NOT NULL DEFAULT '',
-			local_amount   INTEGER,
-			local_currency TEXT    NOT NULL DEFAULT ''
+			local_amount   TEXT    NOT NULL DEFAULT '',
+			emoji          TEXT    NOT NULL DEFAULT '',
+			source_desc    TEXT    NOT NULL DEFAULT ''
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_transactions_account

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -46,18 +46,25 @@ func migrate(db *sql.DB) error {
 		);
 
 		CREATE TABLE IF NOT EXISTS transactions (
-			id          INTEGER PRIMARY KEY AUTOINCREMENT,
-			account_id  INTEGER NOT NULL REFERENCES accounts(id),
-			date        TEXT    NOT NULL,
-			description TEXT    NOT NULL DEFAULT '',
-			amount      INTEGER NOT NULL,
-			category    TEXT    NOT NULL DEFAULT ''
+			id             INTEGER PRIMARY KEY AUTOINCREMENT,
+			account_id     INTEGER NOT NULL REFERENCES accounts(id),
+			date           TEXT    NOT NULL,
+			description    TEXT    NOT NULL DEFAULT '',
+			amount         INTEGER NOT NULL,
+			category       TEXT    NOT NULL DEFAULT '',
+			external_id    TEXT,
+			notes          TEXT    NOT NULL DEFAULT '',
+			type           TEXT    NOT NULL DEFAULT '',
+			local_amount   INTEGER,
+			local_currency TEXT    NOT NULL DEFAULT ''
 		);
 
 		CREATE INDEX IF NOT EXISTS idx_transactions_account
 			ON transactions(account_id);
 		CREATE INDEX IF NOT EXISTS idx_transactions_date
 			ON transactions(date);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_transactions_external_id
+			ON transactions(external_id) WHERE external_id IS NOT NULL;
 	`)
 	return err
 }

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -274,16 +274,17 @@ func AllTransactions(db *sql.DB, offset, limit int) ([]TransactionRow, int, erro
 
 // ImportTransaction holds the data needed to bulk-insert an imported transaction.
 type ImportTransaction struct {
-	AccountID     int64
-	Date          time.Time
-	Description   string
-	Amount        int64
-	Category      string
-	ExternalID    string
-	Notes         string
-	Type          string
-	LocalAmount   *int64
-	LocalCurrency string
+	AccountID   int64
+	Date        time.Time
+	Description string
+	Amount      int64
+	Category    string
+	ExternalID  string
+	Notes       string
+	Type        string
+	LocalAmount string
+	Emoji       string
+	SourceDesc  string
 }
 
 // ExistingExternalIDs returns a set of all non-NULL external_id values.
@@ -319,8 +320,8 @@ func BulkInsertTransactions(db *sql.DB, txns []ImportTransaction) (int, error) {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(`
-		INSERT INTO transactions (account_id, date, description, amount, category, external_id, notes, type, local_amount, local_currency)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO transactions (account_id, date, description, amount, category, external_id, notes, type, local_amount, emoji, source_desc)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("preparing insert: %w", err)
@@ -338,7 +339,8 @@ func BulkInsertTransactions(db *sql.DB, txns []ImportTransaction) (int, error) {
 			t.Notes,
 			t.Type,
 			t.LocalAmount,
-			t.LocalCurrency,
+			t.Emoji,
+			t.SourceDesc,
 		)
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -272,6 +272,91 @@ func AllTransactions(db *sql.DB, offset, limit int) ([]TransactionRow, int, erro
 	return out, total, nil
 }
 
+// ImportTransaction holds the data needed to bulk-insert an imported transaction.
+type ImportTransaction struct {
+	AccountID     int64
+	Date          time.Time
+	Description   string
+	Amount        int64
+	Category      string
+	ExternalID    string
+	Notes         string
+	Type          string
+	LocalAmount   *int64
+	LocalCurrency string
+}
+
+// ExistingExternalIDs returns a set of all non-NULL external_id values.
+func ExistingExternalIDs(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT external_id FROM transactions WHERE external_id IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("querying external IDs: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning external ID: %w", err)
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}
+
+// BulkInsertTransactions inserts multiple transactions in a single DB transaction.
+// It returns the number of rows inserted.
+func BulkInsertTransactions(db *sql.DB, txns []ImportTransaction) (int, error) {
+	if len(txns) == 0 {
+		return 0, nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO transactions (account_id, date, description, amount, category, external_id, notes, type, local_amount, local_currency)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("preparing insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, t := range txns {
+		_, err := stmt.Exec(
+			t.AccountID,
+			t.Date.Format("2006-01-02"),
+			t.Description,
+			t.Amount,
+			t.Category,
+			t.ExternalID,
+			t.Notes,
+			t.Type,
+			t.LocalAmount,
+			t.LocalCurrency,
+		)
+		if err != nil {
+			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
+				return 0, fmt.Errorf("duplicate transaction ID %q already exists", t.ExternalID)
+			}
+			if strings.Contains(err.Error(), "FOREIGN KEY constraint failed") {
+				return 0, fmt.Errorf("account does not exist")
+			}
+			return 0, fmt.Errorf("inserting transaction: %w", err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("committing transaction: %w", err)
+	}
+	return len(txns), nil
+}
+
 // MonthSummary returns income and expense totals for the given year/month.
 func MonthSummary(db *sql.DB, year int, month time.Month) (MonthlySummary, error) {
 	start := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -682,15 +682,16 @@ func TestBulkInsertTransactions_Valid(t *testing.T) {
 			Type:        "card_payment",
 		},
 		{
-			AccountID:     acctID,
-			Date:          time.Date(2026, 1, 11, 0, 0, 0, 0, time.UTC),
-			Description:   "Cafe",
-			Amount:        -500,
-			Category:      "eating_out",
-			ExternalID:    "tx_002",
-			Type:          "card_payment",
-			LocalAmount:   ptrInt64(-625),
-			LocalCurrency: "EUR",
+			AccountID:   acctID,
+			Date:        time.Date(2026, 1, 11, 0, 0, 0, 0, time.UTC),
+			Description: "Cafe",
+			Amount:      -500,
+			Category:    "eating_out",
+			ExternalID:  "tx_002",
+			Type:        "card_payment",
+			LocalAmount: "-6.25 EUR",
+			Emoji:       "☕",
+			SourceDesc:  "cafe payment",
 		},
 		{
 			AccountID:   acctID,
@@ -755,8 +756,4 @@ func TestBulkInsertTransactions_DuplicateExternalID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for duplicate external ID")
 	}
-}
-
-func ptrInt64(v int64) *int64 {
-	return &v
 }

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -48,6 +48,18 @@ func insertTestTransaction(t *testing.T, db *sql.DB, accountID int64, date strin
 	}
 }
 
+// insertTestTransactionWithExtID inserts a transaction with an external_id directly via SQL.
+func insertTestTransactionWithExtID(t *testing.T, db *sql.DB, accountID int64, date string, desc string, amount int64, extID string) {
+	t.Helper()
+	_, err := db.Exec(
+		`INSERT INTO transactions (account_id, date, description, amount, category, external_id) VALUES (?, ?, ?, ?, '', ?)`,
+		accountID, date, desc, amount, extID,
+	)
+	if err != nil {
+		t.Fatalf("inserting test transaction with ext ID: %v", err)
+	}
+}
+
 // --- InsertAccount tests ---
 
 func TestInsertAccount_Valid(t *testing.T) {
@@ -617,4 +629,134 @@ func TestMonthSummary_OnlyIncludesSpecifiedMonth(t *testing.T) {
 	if ms.Income != 300000 {
 		t.Errorf("expected income 300000 (Feb only), got %d", ms.Income)
 	}
+}
+
+// --- ExistingExternalIDs tests ---
+
+func TestExistingExternalIDs_Empty(t *testing.T) {
+	db := testDB(t)
+	ids, err := ExistingExternalIDs(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected 0 IDs, got %d", len(ids))
+	}
+}
+
+func TestExistingExternalIDs_IgnoresNullExternalIDs(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	// Insert a normal transaction (NULL external_id)
+	insertTestTransaction(t, db, acctID, "2026-01-15", "Salary", 150000)
+	// Insert one with external_id
+	insertTestTransactionWithExtID(t, db, acctID, "2026-01-16", "Coffee", -350, "tx_abc")
+
+	ids, err := ExistingExternalIDs(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 ID, got %d", len(ids))
+	}
+	if !ids["tx_abc"] {
+		t.Errorf("expected 'tx_abc' in set")
+	}
+}
+
+// --- BulkInsertTransactions tests ---
+
+func TestBulkInsertTransactions_Valid(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+
+	txns := []ImportTransaction{
+		{
+			AccountID:   acctID,
+			Date:        time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+			Description: "Tesco",
+			Amount:      -1550,
+			Category:    "groceries",
+			ExternalID:  "tx_001",
+			Notes:       "weekly shop",
+			Type:        "card_payment",
+		},
+		{
+			AccountID:     acctID,
+			Date:          time.Date(2026, 1, 11, 0, 0, 0, 0, time.UTC),
+			Description:   "Cafe",
+			Amount:        -500,
+			Category:      "eating_out",
+			ExternalID:    "tx_002",
+			Type:          "card_payment",
+			LocalAmount:   ptrInt64(-625),
+			LocalCurrency: "EUR",
+		},
+		{
+			AccountID:   acctID,
+			Date:        time.Date(2026, 1, 12, 0, 0, 0, 0, time.UTC),
+			Description: "Salary",
+			Amount:      300000,
+			Category:    "income",
+			ExternalID:  "tx_003",
+			Type:        "deposit",
+		},
+	}
+
+	count, err := BulkInsertTransactions(db, txns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 inserted, got %d", count)
+	}
+
+	// Verify all rows exist
+	all, total, err := AllTransactions(db, 0, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("expected 3 total, got %d", total)
+	}
+	// Verify the first row (most recent by date)
+	if all[0].Description != "Salary" {
+		t.Errorf("expected 'Salary', got %q", all[0].Description)
+	}
+}
+
+func TestBulkInsertTransactions_EmptySlice(t *testing.T) {
+	db := testDB(t)
+	count, err := BulkInsertTransactions(db, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected 0 inserted, got %d", count)
+	}
+}
+
+func TestBulkInsertTransactions_DuplicateExternalID(t *testing.T) {
+	db := testDB(t)
+	acctID := insertTestAccount(t, db, "Main", "current")
+	insertTestTransactionWithExtID(t, db, acctID, "2026-01-10", "Existing", -1000, "tx_dup")
+
+	txns := []ImportTransaction{
+		{
+			AccountID:   acctID,
+			Date:        time.Date(2026, 1, 11, 0, 0, 0, 0, time.UTC),
+			Description: "Duplicate",
+			Amount:      -500,
+			ExternalID:  "tx_dup",
+		},
+	}
+
+	_, err := BulkInsertTransactions(db, txns)
+	if err == nil {
+		t.Fatal("expected error for duplicate external ID")
+	}
+}
+
+func ptrInt64(v int64) *int64 {
+	return &v
 }

--- a/internal/ui/import_form.go
+++ b/internal/ui/import_form.go
@@ -1,0 +1,475 @@
+package ui
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"budgie/internal/csvimport"
+	"budgie/internal/db"
+	"budgie/internal/model"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// impFormField tracks which field is focused in the import form.
+type impFormField int
+
+const (
+	impFieldPath impFormField = iota
+	impFieldAccount
+	impFieldSubmit
+	impFieldCount // sentinel for wrapping
+)
+
+// impState tracks the current phase of the import flow.
+type impState int
+
+const (
+	impStateForm impState = iota
+	impStatePreview
+	impStateResult
+)
+
+// importAccountsLoadedMsg delivers accounts to the import form.
+type importAccountsLoadedMsg struct {
+	accounts []model.Account
+	err      error
+}
+
+// importCSVParsedMsg delivers parsed CSV data and existing external IDs.
+type importCSVParsedMsg struct {
+	transactions []csvimport.MonzoTransaction
+	existing     map[string]bool
+	err          error
+}
+
+// importCompletedMsg delivers the result of a bulk insert.
+type importCompletedMsg struct {
+	imported int
+	skipped  int
+	err      error
+}
+
+// importFormCancelledMsg is sent when the user cancels the import form.
+type importFormCancelledMsg struct{}
+
+// importDoneMsg is sent when the user dismisses the result screen.
+type importDoneMsg struct{}
+
+type importFormModel struct {
+	database     *sql.DB
+	accounts     []model.Account
+	accountIndex int
+	pathInput    textinput.Model
+	focused      impFormField
+	err          string
+	loading      bool
+	state        impState
+	parsed       []csvimport.MonzoTransaction
+	toImport     []db.ImportTransaction
+	skippedCount int
+	importedCount int
+}
+
+func newImportFormModel(database *sql.DB) importFormModel {
+	pathIn := textinput.New()
+	pathIn.Placeholder = "~/Downloads/monzo.csv"
+	pathIn.CharLimit = 256
+	pathIn.Focus()
+
+	return importFormModel{
+		database: database,
+		pathInput: pathIn,
+		focused:  impFieldPath,
+		loading:  true,
+		state:    impStateForm,
+	}
+}
+
+func (m importFormModel) Init() tea.Cmd {
+	database := m.database
+	return func() tea.Msg {
+		accounts, err := db.ListAccounts(database)
+		return importAccountsLoadedMsg{accounts: accounts, err: err}
+	}
+}
+
+func (m importFormModel) Update(msg tea.Msg) (importFormModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case importAccountsLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		if len(msg.accounts) == 0 {
+			m.err = "No accounts exist. Create an account first."
+			return m, nil
+		}
+		m.accounts = msg.accounts
+		return m, nil
+
+	case importCSVParsedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			m.state = impStateForm
+			return m, nil
+		}
+		m.parsed = msg.transactions
+		accountID := m.accounts[m.accountIndex].ID
+
+		// Filter duplicates
+		var toImport []db.ImportTransaction
+		skipped := 0
+		for _, tx := range msg.transactions {
+			if msg.existing[tx.ExternalID] {
+				skipped++
+				continue
+			}
+			toImport = append(toImport, db.ImportTransaction{
+				AccountID:     accountID,
+				Date:          tx.Date,
+				Description:   tx.Description,
+				Amount:        tx.Amount,
+				Category:      tx.Category,
+				ExternalID:    tx.ExternalID,
+				Notes:         tx.Notes,
+				Type:          tx.Type,
+				LocalAmount:   tx.LocalAmount,
+				LocalCurrency: tx.LocalCurrency,
+			})
+		}
+		m.toImport = toImport
+		m.skippedCount = skipped
+		m.state = impStatePreview
+		return m, nil
+
+	case importCompletedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			m.state = impStatePreview
+			return m, nil
+		}
+		m.importedCount = msg.imported
+		m.state = impStateResult
+		return m, nil
+
+	case tea.KeyMsg:
+		switch m.state {
+		case impStateForm:
+			return m.updateForm(msg)
+		case impStatePreview:
+			return m.updatePreview(msg)
+		case impStateResult:
+			return m.updateResult(msg)
+		}
+	}
+
+	// Pass through non-key messages to text input
+	if m.state == impStateForm && m.focused == impFieldPath {
+		var cmd tea.Cmd
+		m.pathInput, cmd = m.pathInput.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m importFormModel) updateForm(msg tea.KeyMsg) (importFormModel, tea.Cmd) {
+	m.err = ""
+
+	switch msg.String() {
+	case "esc":
+		return m, func() tea.Msg { return importFormCancelledMsg{} }
+
+	case "tab", "down":
+		return m.focusNext(), nil
+
+	case "shift+tab", "up":
+		return m.focusPrev(), nil
+
+	case "enter":
+		if m.focused == impFieldSubmit {
+			return m.submitForm()
+		}
+		return m.focusNext(), nil
+
+	case "left":
+		if m.focused == impFieldAccount && len(m.accounts) > 0 {
+			m.accountIndex = (m.accountIndex - 1 + len(m.accounts)) % len(m.accounts)
+			return m, nil
+		}
+
+	case "right":
+		if m.focused == impFieldAccount && len(m.accounts) > 0 {
+			m.accountIndex = (m.accountIndex + 1) % len(m.accounts)
+			return m, nil
+		}
+	}
+
+	// Update the focused text input
+	if m.focused == impFieldPath {
+		var cmd tea.Cmd
+		m.pathInput, cmd = m.pathInput.Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m importFormModel) updatePreview(msg tea.KeyMsg) (importFormModel, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.state = impStateForm
+		m.err = ""
+		return m, nil
+
+	case "enter":
+		if len(m.toImport) == 0 {
+			return m, func() tea.Msg { return importDoneMsg{} }
+		}
+		m.loading = true
+		database := m.database
+		toImport := m.toImport
+		skipped := m.skippedCount
+		return m, func() tea.Msg {
+			count, err := db.BulkInsertTransactions(database, toImport)
+			return importCompletedMsg{imported: count, skipped: skipped, err: err}
+		}
+	}
+	return m, nil
+}
+
+func (m importFormModel) updateResult(msg tea.KeyMsg) (importFormModel, tea.Cmd) {
+	return m, func() tea.Msg { return importDoneMsg{} }
+}
+
+func (m importFormModel) focusField(field impFormField) importFormModel {
+	m.pathInput.Blur()
+	m.focused = field
+	if field == impFieldPath {
+		m.pathInput.Focus()
+	}
+	return m
+}
+
+func (m importFormModel) focusNext() importFormModel {
+	next := (m.focused + 1) % impFieldCount
+	return m.focusField(next)
+}
+
+func (m importFormModel) focusPrev() importFormModel {
+	prev := (m.focused - 1 + impFieldCount) % impFieldCount
+	return m.focusField(prev)
+}
+
+func (m importFormModel) submitForm() (importFormModel, tea.Cmd) {
+	path := strings.TrimSpace(m.pathInput.Value())
+	if path == "" {
+		m.err = "File path is required"
+		return m, nil
+	}
+	if len(m.accounts) == 0 {
+		m.err = "No accounts exist. Create an account first."
+		return m, nil
+	}
+
+	m.loading = true
+	database := m.database
+	return m, func() tea.Msg {
+		txns, err := csvimport.ParseMonzoCSV(path)
+		if err != nil {
+			return importCSVParsedMsg{err: err}
+		}
+		existing, err := db.ExistingExternalIDs(database)
+		if err != nil {
+			return importCSVParsedMsg{err: err}
+		}
+		return importCSVParsedMsg{transactions: txns, existing: existing}
+	}
+}
+
+func (m importFormModel) View() string {
+	switch m.state {
+	case impStatePreview:
+		return m.viewPreview()
+	case impStateResult:
+		return m.viewResult()
+	default:
+		return m.viewForm()
+	}
+}
+
+func (m importFormModel) viewForm() string {
+	var b strings.Builder
+
+	b.WriteString(sectionTitle.Render("Import Transactions"))
+	b.WriteString("\n\n")
+
+	if m.loading {
+		b.WriteString("  Loading accounts...")
+		return b.String()
+	}
+
+	labelW := 12
+
+	// Path input
+	label := m.impLabelStyle(impFieldPath, labelW)
+	b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("CSV File:"), m.pathInput.View()))
+
+	// Account picker
+	label = m.impLabelStyle(impFieldAccount, labelW)
+	if len(m.accounts) > 0 {
+		b.WriteString(fmt.Sprintf("  %s %s\n", label.Render("Account:"), m.renderAccountPicker()))
+	} else {
+		b.WriteString(fmt.Sprintf("  %s (none)\n", label.Render("Account:")))
+	}
+
+	// Error
+	if m.err != "" {
+		b.WriteString(fmt.Sprintf("\n  %s\n", formErrorStyle.Render(m.err)))
+	}
+
+	// Submit button
+	b.WriteString("\n")
+	if m.focused == impFieldSubmit {
+		b.WriteString(fmt.Sprintf("  %s", formActiveButton.Render("Import")))
+	} else {
+		b.WriteString(fmt.Sprintf("  %s", formButtonStyle.Render("Import")))
+	}
+	b.WriteString("\n")
+
+	// Help
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  tab/shift+tab: navigate  enter: submit  esc: cancel"))
+
+	return b.String()
+}
+
+func (m importFormModel) viewPreview() string {
+	var b strings.Builder
+
+	b.WriteString(sectionTitle.Render("Import Preview"))
+	b.WriteString("\n\n")
+
+	totalParsed := len(m.parsed)
+	willImport := len(m.toImport)
+
+	b.WriteString(fmt.Sprintf("  Found %d transactions", totalParsed))
+	if m.skippedCount > 0 {
+		b.WriteString(fmt.Sprintf(", skipping %d duplicates", m.skippedCount))
+	}
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Will import %d new transactions\n", willImport))
+
+	if willImport > 0 {
+		b.WriteString("\n")
+
+		// Determine column widths
+		dateW := len("Date")
+		descW := len("Description")
+		catW := len("Category")
+		amtW := len("Amount")
+
+		limit := willImport
+		if limit > 10 {
+			limit = 10
+		}
+
+		for _, tx := range m.toImport[:limit] {
+			ds := formatDate(tx.Date)
+			if len(ds) > dateW {
+				dateW = len(ds)
+			}
+			if len(tx.Description) > descW {
+				descW = len(tx.Description)
+			}
+			if len(tx.Category) > catW {
+				catW = len(tx.Category)
+			}
+			as := formatSignedPence(tx.Amount)
+			if len(as) > amtW {
+				amtW = len(as)
+			}
+		}
+
+		// Cap description width
+		if descW > 30 {
+			descW = 30
+		}
+
+		fmtRow := fmt.Sprintf("  %%-%ds  %%-%ds  %%-%ds  %%%ds", dateW, descW, catW, amtW)
+
+		header := fmt.Sprintf(fmtRow, "Date", "Description", "Category", "Amount")
+		b.WriteString(tableHeader.Render(header))
+		b.WriteString("\n")
+
+		for _, tx := range m.toImport[:limit] {
+			desc := tx.Description
+			if len(desc) > descW {
+				desc = desc[:descW-1] + "…"
+			}
+			row := fmt.Sprintf(fmtRow, formatDate(tx.Date), desc, tx.Category, formatSignedPence(tx.Amount))
+			b.WriteString(row)
+			b.WriteString("\n")
+		}
+
+		if willImport > 10 {
+			b.WriteString(fmt.Sprintf("\n  ... and %d more\n", willImport-10))
+		}
+	}
+
+	// Error
+	if m.err != "" {
+		b.WriteString(fmt.Sprintf("\n  %s\n", formErrorStyle.Render(m.err)))
+	}
+
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  enter: confirm  esc: back"))
+
+	return b.String()
+}
+
+func (m importFormModel) viewResult() string {
+	var b strings.Builder
+
+	b.WriteString(sectionTitle.Render("Import Complete"))
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("  Imported %d transactions", m.importedCount))
+	if m.skippedCount > 0 {
+		b.WriteString(fmt.Sprintf(", skipped %d duplicates", m.skippedCount))
+	}
+	b.WriteString("\n")
+
+	b.WriteString("\n")
+	b.WriteString(helpStyle.Render("  press any key to continue"))
+
+	return b.String()
+}
+
+func (m importFormModel) impLabelStyle(field impFormField, width int) lipgloss.Style {
+	if m.focused == field {
+		return formActiveLabel.Width(width)
+	}
+	return formLabelStyle.Width(width)
+}
+
+func (m importFormModel) renderAccountPicker() string {
+	var parts []string
+	for i, a := range m.accounts {
+		s := a.Name
+		if i == m.accountIndex {
+			if m.focused == impFieldAccount {
+				s = formActiveButton.Render(s)
+			} else {
+				s = lipgloss.NewStyle().Bold(true).Render("[" + s + "]")
+			}
+		}
+		parts = append(parts, s)
+	}
+	return strings.Join(parts, "  ")
+}

--- a/internal/ui/import_form.go
+++ b/internal/ui/import_form.go
@@ -131,16 +131,17 @@ func (m importFormModel) Update(msg tea.Msg) (importFormModel, tea.Cmd) {
 				continue
 			}
 			toImport = append(toImport, db.ImportTransaction{
-				AccountID:     accountID,
-				Date:          tx.Date,
-				Description:   tx.Description,
-				Amount:        tx.Amount,
-				Category:      tx.Category,
-				ExternalID:    tx.ExternalID,
-				Notes:         tx.Notes,
-				Type:          tx.Type,
-				LocalAmount:   tx.LocalAmount,
-				LocalCurrency: tx.LocalCurrency,
+				AccountID:   accountID,
+				Date:        tx.Date,
+				Description: tx.Description,
+				Amount:      tx.Amount,
+				Category:    tx.Category,
+				ExternalID:  tx.ExternalID,
+				Notes:       tx.Notes,
+				Type:        tx.Type,
+				LocalAmount: tx.LocalAmount,
+				Emoji:       tx.Emoji,
+				SourceDesc:  tx.SourceDesc,
 			})
 		}
 		m.toImport = toImport

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -14,6 +14,7 @@ const (
 	viewAccountForm
 	viewTransactionForm
 	viewTransactionList
+	viewImportForm
 )
 
 var (
@@ -34,6 +35,7 @@ type Model struct {
 	accountForm     accountFormModel
 	transactionForm transactionFormModel
 	transactionList transactionListModel
+	importForm      importFormModel
 }
 
 func New(db *sql.DB) Model {
@@ -79,7 +81,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.summary = newSummaryModel(m.db)
 		return m, m.summary.Init()
 
-	case accountFormCancelledMsg, transactionFormCancelledMsg:
+	case importDoneMsg:
+		m.active = viewSummary
+		m.summary = newSummaryModel(m.db)
+		return m, m.summary.Init()
+
+	case accountFormCancelledMsg, transactionFormCancelledMsg, importFormCancelledMsg:
 		m.active = viewSummary
 		return m, nil
 	}
@@ -93,6 +100,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateTransactionForm(msg)
 	case viewTransactionList:
 		return m.updateTransactionList(msg)
+	case viewImportForm:
+		return m.updateImportForm(msg)
 	}
 
 	return m, nil
@@ -115,6 +124,10 @@ func (m Model) updateSummary(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.active = viewTransactionList
 			m.transactionList = newTransactionListModel(m.db)
 			return m, m.transactionList.Init()
+		case "i":
+			m.active = viewImportForm
+			m.importForm = newImportFormModel(m.db)
+			return m, m.importForm.Init()
 		}
 	}
 
@@ -141,6 +154,12 @@ func (m Model) updateTransactionList(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m Model) updateImportForm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.importForm, cmd = m.importForm.Update(msg)
+	return m, cmd
+}
+
 func (m Model) View() string {
 	title := titleStyle.Render("budgie")
 
@@ -150,7 +169,7 @@ func (m Model) View() string {
 	switch m.active {
 	case viewSummary:
 		content = m.summary.View()
-		help = helpStyle.Render("a: add account  t: add transaction  l: transactions  q: quit")
+		help = helpStyle.Render("a: add account  t: add transaction  l: transactions  i: import  q: quit")
 	case viewAccountForm:
 		content = m.accountForm.View()
 		help = ""
@@ -160,6 +179,9 @@ func (m Model) View() string {
 	case viewTransactionList:
 		content = m.transactionList.View()
 		help = helpStyle.Render("e/enter: edit  esc: back  ↑/↓: scroll  ←/→: page")
+	case viewImportForm:
+		content = m.importForm.View()
+		help = ""
 	}
 
 	return title + "\n\n" + content + "\n\n" + help + "\n"


### PR DESCRIPTION
## Summary
- Extends transactions schema with `external_id`, `notes`, `type`, `local_amount`, `local_currency` columns and a partial unique index on `external_id` for dedup
- Adds `internal/csvimport` package with Monzo CSV parser (`ParseMonzoCSV`) — pure parsing, no DB dependency, 7 tests
- Adds `ExistingExternalIDs` and `BulkInsertTransactions` DB functions with transactional bulk insert and friendly constraint violation messages, 5 tests
- Adds 3-state import UI (`i` from dashboard): file path + account picker → preview table with duplicate counts → result summary

Closes #17, closes #18

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` passes
- [x] Delete local DB file (schema changed, pre-release convention)
- [x] Run app, press `i`, enter path to a Monzo CSV, select account, verify preview shows correct counts
- [x] Confirm import, verify transactions appear in transaction list (`l`)
- [ ] Re-import same file, verify all rows are skipped as duplicates
- [x] Test with a CSV containing foreign currency transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)