### PR TITLE
Add net worth over time chart view

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/guptarohit/asciigraph v0.7.3 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/guptarohit/asciigraph v0.7.3 h1:p05XDDn7cBTWiBqWb30mrwxd6oU0claAjqeytllnsPY=
+github.com/guptarohit/asciigraph v0.7.3/go.mod h1:dYl5wwK4gNsnFf9Zp+l06rFiDZ5YtXM6x7SRWZ3KGag=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/db/queries.go
+++ b/internal/db/queries.go
@@ -249,6 +249,56 @@ func AllTransactions(db *sql.DB, offset, limit int) ([]TransactionRow, int, erro
 	return out, total, nil
 }
 
+// MonthlyFinances holds income, expenses, and cumulative net worth for a month.
+type MonthlyFinances struct {
+	Year     int
+	Month    time.Month
+	Income   int64 // positive, pence
+	Expenses int64 // negative, pence
+	NetWorth int64 // cumulative, pence
+}
+
+// MonthlyFinancesByMonth returns monthly income, expenses, and cumulative net
+// worth for every month that has transactions, in chronological order.
+func MonthlyFinancesByMonth(db *sql.DB) ([]MonthlyFinances, error) {
+	rows, err := db.Query(`
+		SELECT
+			strftime('%Y', date) AS yr,
+			strftime('%m', date) AS mo,
+			COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0),
+			COALESCE(SUM(CASE WHEN amount < 0 THEN amount ELSE 0 END), 0)
+		FROM transactions
+		GROUP BY yr, mo
+		ORDER BY yr, mo
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying monthly finances: %w", err)
+	}
+	defer rows.Close()
+
+	var out []MonthlyFinances
+	var cumulative int64
+	for rows.Next() {
+		var mf MonthlyFinances
+		var yrStr, moStr string
+		if err := rows.Scan(&yrStr, &moStr, &mf.Income, &mf.Expenses); err != nil {
+			return nil, fmt.Errorf("scanning monthly finances: %w", err)
+		}
+
+		var yr, mo int
+		fmt.Sscanf(yrStr, "%d", &yr)
+		fmt.Sscanf(moStr, "%d", &mo)
+		mf.Year = yr
+		mf.Month = time.Month(mo)
+
+		cumulative += mf.Income + mf.Expenses
+		mf.NetWorth = cumulative
+
+		out = append(out, mf)
+	}
+	return out, rows.Err()
+}
+
 // MonthSummary returns income and expense totals for the given year/month.
 func MonthSummary(db *sql.DB, year int, month time.Month) (MonthlySummary, error) {
 	start := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)

--- a/internal/db/queries_test.go
+++ b/internal/db/queries_test.go
@@ -552,3 +552,98 @@ func TestMonthSummary_OnlyIncludesSpecifiedMonth(t *testing.T) {
 		t.Errorf("expected income 300000 (Feb only), got %d", ms.Income)
 	}
 }
+
+// --- MonthlyFinancesByMonth tests ---
+
+func TestMonthlyFinancesByMonth_Empty(t *testing.T) {
+	db := testDB(t)
+	result, err := MonthlyFinancesByMonth(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(result))
+	}
+}
+
+func TestMonthlyFinancesByMonth_SingleMonth(t *testing.T) {
+	db := testDB(t)
+	id := insertTestAccount(t, db, "Main", "current")
+	insertTestTransaction(t, db, id, "2026-03-05", "Salary", 300000)
+	insertTestTransaction(t, db, id, "2026-03-10", "Rent", -100000)
+	insertTestTransaction(t, db, id, "2026-03-15", "Food", -25000)
+
+	result, err := MonthlyFinancesByMonth(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	mf := result[0]
+	if mf.Year != 2026 || mf.Month != time.March {
+		t.Errorf("expected 2026/March, got %d/%v", mf.Year, mf.Month)
+	}
+	if mf.Income != 300000 {
+		t.Errorf("expected income 300000, got %d", mf.Income)
+	}
+	if mf.Expenses != -125000 {
+		t.Errorf("expected expenses -125000, got %d", mf.Expenses)
+	}
+	if mf.NetWorth != 175000 {
+		t.Errorf("expected net worth 175000, got %d", mf.NetWorth)
+	}
+}
+
+func TestMonthlyFinancesByMonth_Cumulative(t *testing.T) {
+	db := testDB(t)
+	id := insertTestAccount(t, db, "Main", "current")
+	insertTestTransaction(t, db, id, "2026-01-10", "Salary", 200000)
+	insertTestTransaction(t, db, id, "2026-01-15", "Rent", -80000)
+	insertTestTransaction(t, db, id, "2026-02-10", "Salary", 200000)
+	insertTestTransaction(t, db, id, "2026-02-15", "Rent", -80000)
+	insertTestTransaction(t, db, id, "2026-02-20", "Food", -30000)
+
+	result, err := MonthlyFinancesByMonth(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+	// Jan: income 200000, expenses -80000, net worth 120000
+	if result[0].NetWorth != 120000 {
+		t.Errorf("expected Jan net worth 120000, got %d", result[0].NetWorth)
+	}
+	// Feb: income 200000, expenses -110000, cumulative net worth 120000+90000=210000
+	if result[1].NetWorth != 210000 {
+		t.Errorf("expected Feb net worth 210000, got %d", result[1].NetWorth)
+	}
+}
+
+func TestMonthlyFinancesByMonth_MultipleAccounts(t *testing.T) {
+	db := testDB(t)
+	id1 := insertTestAccount(t, db, "Current", "current")
+	id2 := insertTestAccount(t, db, "Savings", "savings")
+	insertTestTransaction(t, db, id1, "2026-04-10", "Salary", 300000)
+	insertTestTransaction(t, db, id1, "2026-04-15", "Rent", -100000)
+	insertTestTransaction(t, db, id2, "2026-04-20", "Interest", 5000)
+
+	result, err := MonthlyFinancesByMonth(db)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result))
+	}
+	mf := result[0]
+	if mf.Income != 305000 {
+		t.Errorf("expected income 305000 (aggregated), got %d", mf.Income)
+	}
+	if mf.Expenses != -100000 {
+		t.Errorf("expected expenses -100000, got %d", mf.Expenses)
+	}
+	if mf.NetWorth != 205000 {
+		t.Errorf("expected net worth 205000, got %d", mf.NetWorth)
+	}
+}

--- a/internal/ui/net_worth_chart.go
+++ b/internal/ui/net_worth_chart.go
@@ -1,0 +1,133 @@
+package ui
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"budgie/internal/db"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/guptarohit/asciigraph"
+)
+
+type chartDataMsg struct {
+	data []db.MonthlyFinances
+	err  error
+}
+
+type chartClosedMsg struct{}
+
+type chartModel struct {
+	database *sql.DB
+	data     []db.MonthlyFinances
+	loaded   bool
+	err      error
+	width    int
+	height   int
+}
+
+func newChartModel(database *sql.DB, width, height int) chartModel {
+	return chartModel{database: database, width: width, height: height}
+}
+
+func (m chartModel) Init() tea.Cmd {
+	return func() tea.Msg {
+		data, err := db.MonthlyFinancesByMonth(m.database)
+		return chartDataMsg{data: data, err: err}
+	}
+}
+
+func (m chartModel) Update(msg tea.Msg) (chartModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case chartDataMsg:
+		if msg.err != nil {
+			m.err = msg.err
+		} else {
+			m.data = msg.data
+			m.loaded = true
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+	case tea.KeyMsg:
+		if msg.String() == "esc" {
+			return m, func() tea.Msg { return chartClosedMsg{} }
+		}
+	}
+	return m, nil
+}
+
+var (
+	chartLegendCyan  = lipgloss.NewStyle().Foreground(lipgloss.Color("14"))
+	chartLegendGreen = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
+	chartLegendRed   = lipgloss.NewStyle().Foreground(lipgloss.Color("9"))
+)
+
+func (m chartModel) View() string {
+	if m.err != nil {
+		return fmt.Sprintf("Error loading chart data: %v", m.err)
+	}
+	if !m.loaded {
+		return "Loading..."
+	}
+	if len(m.data) == 0 {
+		return "No transaction data yet."
+	}
+
+	var b strings.Builder
+	b.WriteString(sectionTitle.Render("Net Worth Over Time"))
+	b.WriteString("\n\n")
+
+	// Build three series: net worth, income, expenses (converted to pounds)
+	netWorth := make([]float64, len(m.data))
+	income := make([]float64, len(m.data))
+	expenses := make([]float64, len(m.data))
+
+	for i, mf := range m.data {
+		netWorth[i] = float64(mf.NetWorth) / 100
+		income[i] = float64(mf.Income) / 100
+		expenses[i] = float64(-mf.Expenses) / 100 // display as positive
+	}
+
+	// Chart dimensions
+	chartWidth := m.width - 14 // room for Y-axis labels and padding
+	if chartWidth < 20 {
+		chartWidth = 20
+	}
+	chartHeight := m.height - 12 // room for title, legend, labels, help
+	if chartHeight < 5 {
+		chartHeight = 5
+	}
+
+	graph := asciigraph.PlotMany(
+		[][]float64{netWorth, income, expenses},
+		asciigraph.Height(chartHeight),
+		asciigraph.Width(chartWidth),
+		asciigraph.SeriesColors(asciigraph.Cyan, asciigraph.Green, asciigraph.Red),
+		asciigraph.Precision(0),
+	)
+	b.WriteString(graph)
+	b.WriteString("\n\n")
+
+	// Month labels
+	b.WriteString("  ")
+	for i, mf := range m.data {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		b.WriteString(fmt.Sprintf("%s %d", mf.Month.String()[:3], mf.Year))
+	}
+	b.WriteString("\n\n")
+
+	// Legend
+	b.WriteString("  ")
+	b.WriteString(chartLegendCyan.Render("--- Net Worth"))
+	b.WriteString("  ")
+	b.WriteString(chartLegendGreen.Render("--- Income"))
+	b.WriteString("  ")
+	b.WriteString(chartLegendRed.Render("--- Expenses"))
+
+	return b.String()
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -14,6 +14,7 @@ const (
 	viewAccountForm
 	viewTransactionForm
 	viewTransactionList
+	viewChart
 )
 
 var (
@@ -34,6 +35,7 @@ type Model struct {
 	accountForm     accountFormModel
 	transactionForm transactionFormModel
 	transactionList transactionListModel
+	chart           chartModel
 }
 
 func New(db *sql.DB) Model {
@@ -64,6 +66,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.summary = newSummaryModel(m.db)
 		return m, m.summary.Init()
 
+	case chartClosedMsg:
+		m.active = viewSummary
+		m.summary = newSummaryModel(m.db)
+		return m, m.summary.Init()
+
 	case accountFormCancelledMsg, transactionFormCancelledMsg, transactionListCancelledMsg:
 		m.active = viewSummary
 		return m, nil
@@ -78,6 +85,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updateTransactionForm(msg)
 	case viewTransactionList:
 		return m.updateTransactionList(msg)
+	case viewChart:
+		return m.updateChart(msg)
 	}
 
 	return m, nil
@@ -100,6 +109,10 @@ func (m Model) updateSummary(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.active = viewTransactionList
 			m.transactionList = newTransactionListModel(m.db)
 			return m, m.transactionList.Init()
+		case "c":
+			m.active = viewChart
+			m.chart = newChartModel(m.db, m.width, m.height)
+			return m, m.chart.Init()
 		}
 	}
 
@@ -126,6 +139,12 @@ func (m Model) updateTransactionList(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m Model) updateChart(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.chart, cmd = m.chart.Update(msg)
+	return m, cmd
+}
+
 func (m Model) View() string {
 	title := titleStyle.Render("budgie")
 
@@ -135,7 +154,7 @@ func (m Model) View() string {
 	switch m.active {
 	case viewSummary:
 		content = m.summary.View()
-		help = helpStyle.Render("a: add account  t: add transaction  l: transactions  q: quit")
+		help = helpStyle.Render("a: add account  t: add transaction  l: transactions  c: chart  q: quit")
 	case viewAccountForm:
 		content = m.accountForm.View()
 		help = ""
@@ -145,6 +164,9 @@ func (m Model) View() string {
 	case viewTransactionList:
 		content = m.transactionList.View()
 		help = helpStyle.Render("esc: back  ↑/↓: scroll  ←/→: page")
+	case viewChart:
+		content = m.chart.View()
+		help = helpStyle.Render("esc: back")
 	}
 
 	return title + "\n\n" + content + "\n\n" + help + "\n"


### PR DESCRIPTION
## Summary
- Add `MonthlyFinancesByMonth` DB query that returns monthly income, expenses, and cumulative net worth in chronological order
- Add new chart view (`internal/ui/net_worth_chart.go`) rendering three series as an ASCII line chart using `asciigraph`: net worth (cyan), income (green), expenses (red)
- Wire chart into dashboard via `c` keyboard shortcut, with `esc` to return

Closes #29

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` passes
- [ ] Run the app, add some transactions across multiple months, press `c` to verify the chart renders correctly
- [ ] Verify `esc` returns to dashboard
- [ ] Resize the terminal window while viewing the chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)